### PR TITLE
InnoSetup fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,12 @@
     "": {
       "name": "elecord-rpc",
       "dependencies": {
-        "innosetup": "^6.4.1",
         "koffi": "^2.9.0",
-        "nssm-bin": "2.24.102",
         "ws": "^8.11.0",
+      },
+      "devDependencies": {
+        "innosetup": "^6.4.1",
+        "nssm-bin": "2.24.102",
       },
     },
   },

--- a/inno.iss
+++ b/inno.iss
@@ -12,7 +12,7 @@
 #define OutputLocation ".\dist"
 
 [Setup]
-AppId={{EC7980B2-20B5-4FEA-BB4F-51C05DA8797B}
+AppId={#MyAppName}-{#MyAppVersion}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 AppVerName={#MyAppName}
@@ -48,11 +48,30 @@ Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 [Run]
 ; post-install, setup windows erpc service
 Filename: "{app}\nssm.exe"; Parameters: "install {#MyAppName} ""{app}\{#MyAppExeName}"""; Flags: runhidden;
-Filename: "{app}\nssm.exe"; Parameters: "set {#MyAppName} AppDirectory ""{app}"""; Flags: runhidden;
+; set description
 Filename: "{app}\nssm.exe"; Parameters: "set {#MyAppName} Description ""{#MyAppDescription}"""; Flags: runhidden;
+; set working directory
+Filename: "{app}\nssm.exe"; Parameters: "set {#MyAppName} AppDirectory ""{app}"""; Flags: runhidden;
+; set start type
+Filename: "{app}\nssm.exe"; Parameters: "set {#MyAppName} Start SERVICE_DELAYED_AUTO_START"; Flags: runhidden;
+; set log file
+Filename: "{app}\nssm.exe"; Parameters: "set {#MyAppName} AppStdout ""{app}\{#MyAppName}.log"""; Flags: runhidden;
+Filename: "{app}\nssm.exe"; Parameters: "set {#MyAppName} AppStderr ""{app}\{#MyAppName}.log"""; Flags: runhidden;
+; set log dispoition
+; https://nssm.cc/usage#io
+; https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#parameters
+Filename: "{app}\nssm.exe"; Parameters: "set {#MyAppName} AppStdoutCreationDisposition 2"; Flags: runhidden;
+Filename: "{app}\nssm.exe"; Parameters: "set {#MyAppName} AppStderrCreationDisposition 2"; Flags: runhidden;
+; start windows erpc service
 Filename: "{app}\nssm.exe"; Parameters: "start {#MyAppName}"; Flags: runhidden;
 
 [UninstallRun]
 ; pre-uninstall, remove windows erpc service
 Filename: "{app}\nssm.exe"; Parameters: "stop {#MyAppName}"; Flags: runhidden; RunOnceId: "StopService";
 Filename: "{app}\nssm.exe"; Parameters: "remove {#MyAppName} confirm"; Flags: runhidden; RunOnceId: "RemoveService";
+
+; regedit
+; Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\elecord-rpc
+
+; nssm
+; .\nssm.exe edit elecord-rpc

--- a/nssm.ps1
+++ b/nssm.ps1
@@ -1,0 +1,18 @@
+# helper script to quickly stop and start the installed elecord-rpc windows service
+# prevents port conflicts during debugging
+
+Write-Host "elecord-rpc service helper"
+
+if (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Host "Must be run as Administrator. Exiting."
+    exit
+}
+
+Write-Host "🛑 Stopping elecord-rpc service..."
+.\node_modules\nssm-bin\nssm.exe stop elecord-rpc
+
+Write-Host "> Press any key to restart the service..."
+$null = $host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
+
+Write-Host "🟢 Starting elecord-rpc service..."
+.\node_modules\nssm-bin\nssm.exe start elecord-rpc

--- a/package.json
+++ b/package.json
@@ -16,14 +16,16 @@
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/elecordapp/elecord-rpc#readme",
   "dependencies": {
-    "innosetup": "^6.4.1",
     "koffi": "^2.9.0",
-    "nssm-bin": "2.24.102",
     "ws": "^8.11.0"
   },
   "trustedDependencies": ["koffi"],
   "type": "module",
   "bin": {
     "elecord-rpc": "src/index.js"
+  },
+  "devDependencies": {
+    "innosetup": "^6.4.1",
+    "nssm-bin": "2.24.102"
   }
 }


### PR DESCRIPTION
Primarily sets additional NSSM parameters:

- Delayed service start-up (`erpc.exe` doesn't have to start immediately on system start-up)
- Add stdout logging (NSSM redirects expected console output to `elecord-rpc.log`)
- Set log file disposition (The log file is replaced on each app start-up)