### PR TITLE
Use package.json app version for Inno Setup

### DIFF
--- a/inno.iss
+++ b/inno.iss
@@ -1,7 +1,7 @@
 ; Inno Setup - Installer for Windows programs
 
 #define MyAppName "elecord-rpc"
-#define MyAppVersion "1.0.0"
+; #define MyAppVersion "1.0.0"
 #define MyAppPublisher "elecord"
 #define MyAppURL "https://elecord.app/"
 #define MyAppExeName "erpc.exe"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "update": "bun update_db.js",
     "compile": "bun build --compile ./src/index.js --outfile dist/erpc --minify --sourcemap",
-    "win32": "bun innosetup-compiler inno.iss --verbose"
+    "win32": "bun innosetup-compiler inno.iss --verbose --d=MyAppVersion=$npm_package_version"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Instead of statically declaring the app's version inside the Inno Setup script. Now, the version number comes directly from package.json when using `bun run win32`.