### PR TITLE
Version over WebSocket bridge

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
       "name": "elecord-rpc",
       "dependencies": {
         "koffi": "^2.9.0",
-        "ws": "^8.11.0",
       },
       "devDependencies": {
         "innosetup": "^6.4.1",
@@ -22,7 +21,5 @@
     "koffi": ["koffi@2.11.0", "", {}, "sha512-AJ6MHz9Z8OIftKu322jrKJFvy/rZTdCD4b7F457WrK71rxYV7O5PSdWsJDN0p3rY1BZaPeLHVwyt4i2Xyk8wJg=="],
 
     "nssm-bin": ["nssm-bin@2.24.102", "", {}, "sha512-GQmndo9KTzvcCd5AErZJpRvUfhK1v7Zs1+lKhIO+cKIzVr4RfkWlD4Qvey+6aeTx7B1Z6JGIf9eLkYGj3q74Cw=="],
-
-    "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "license": "AGPL-3.0-only",
   "homepage": "https://github.com/elecordapp/elecord-rpc#readme",
   "dependencies": {
-    "koffi": "^2.9.0",
-    "ws": "^8.11.0"
+    "koffi": "^2.9.0"
   },
   "trustedDependencies": ["koffi"],
   "type": "module",


### PR DESCRIPTION
- Removes node.js `ws` dependency
    - WebSocket clients created by importing the ws package are changed by Bun. Where Bun will instead use the their own implementation of WebSocket. Meaning the need to include the ws dependency is now redundant.
- Add `getAppVersion`
  - As erpc currently has no automatic update feature, elecord will have to determine if the users erpc version is outdated or not.